### PR TITLE
Added proxy for fetch requests from frontend to backend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,6 @@
 {
   "name": "frontend",
+  "proxy": "http://localhost:5000/",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -46,6 +47,5 @@
   "devDependencies": {
     "cypress": "^12.16.0",
     "prettier": "^2.8.8"
-  },
-  "proxy":5000
+  }
 }


### PR DESCRIPTION
I added a proxy to the frontend package.json to be able to make fetch calls to our custom API from the frontend. I tested this and it's working with an axios post call to `api/va/state`
@NoodlesOver 